### PR TITLE
fix: reservation-service 필드명 오타 및 권한 오타 수정

### DIFF
--- a/reservation-service/src/main/java/com/tablekok/reservation_service/application/client/dto/response/GetStoreReservationPolicyResponse.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/application/client/dto/response/GetStoreReservationPolicyResponse.java
@@ -16,7 +16,7 @@ public record GetStoreReservationPolicyResponse(
 	LocalTime dailyReservationStartTime,
 	LocalTime dailyReservationEndTime,
 
-	int minHeadCount,
+	int minHeadcount,
 	int maxHeadcount,
 
 	boolean isDepositRequired,
@@ -24,7 +24,7 @@ public record GetStoreReservationPolicyResponse(
 	boolean isActive
 ) {
 	public static StoreReservationPolicy toVo(GetStoreReservationPolicyResponse response) {
-		return StoreReservationPolicy.of(response.isActive, response.maxHeadcount, response.minHeadCount,
+		return StoreReservationPolicy.of(response.isActive, response.maxHeadcount, response.minHeadcount,
 			response.monthlyOpenDay,
 			response.openTime);
 	}

--- a/reservation-service/src/main/java/com/tablekok/reservation_service/domain/service/ReservationDomainService.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/domain/service/ReservationDomainService.java
@@ -105,7 +105,7 @@ public class ReservationDomainService {
 		if (headcount > policy.getMaxHeadcount()) {
 			throw new AppException(ReservationDomainErrorCode.INVALID_RESERVATION_POLICY);
 		}
-		if (headcount < policy.getMinHeadCount()) {
+		if (headcount < policy.getMinHeadcount()) {
 			throw new AppException(ReservationDomainErrorCode.INVALID_RESERVATION_POLICY);
 		}
 	}

--- a/reservation-service/src/main/java/com/tablekok/reservation_service/domain/vo/StoreReservationPolicy.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/domain/vo/StoreReservationPolicy.java
@@ -11,16 +11,16 @@ import lombok.Getter;
 public class StoreReservationPolicy {
 	private boolean isActive;       // 예약 가능 여부
 	private int maxHeadcount;        // 예약 최대 인원
-	private int minHeadCount;        // 예약 최소 인원
+	private int minHeadcount;        // 예약 최소 인원
 	private int monthlyOpenDay;     // 다음 달 예약이 풀리는 일
 	private LocalTime openTime;        // 다음 달 예약이 풀리는 시간
 
 	public static StoreReservationPolicy of(
-		boolean isActive, int maxHeadcount, int minHeadCount, int monthlyOpenDay, LocalTime openTime) {
+		boolean isActive, int maxHeadcount, int minHeadcount, int monthlyOpenDay, LocalTime openTime) {
 		return StoreReservationPolicy.builder()
 			.isActive(isActive)
 			.maxHeadcount(maxHeadcount)
-			.minHeadCount(minHeadCount)
+			.minHeadcount(minHeadcount)
 			.monthlyOpenDay(monthlyOpenDay)
 			.openTime(openTime)
 			.build();

--- a/reservation-service/src/main/java/com/tablekok/reservation_service/presentation/ReservationController.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/presentation/ReservationController.java
@@ -103,7 +103,7 @@ public class ReservationController {
 	}
 
 	// 예약 취소. 고객, 오너 전략패턴 적용
-	@PreAuthorize("hasAnyRole('COSTOMER', 'OWNER')")
+	@PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER')")
 	@PatchMapping("/{reservationId}/cancel")
 	public ResponseEntity<ApiResponse<Void>> cancelReservation(
 		@PathVariable("reservationId") UUID reservationId,


### PR DESCRIPTION
## 🔗 Issue 번호
- X

## 🛠 작업 내역
- 오타 수정

## 🔄 변경 사항
- minHeadCount → minHeadcount (store-service 응답 필드명과 불일치로 역직렬화 실패)
- COSTOMER → CUSTOMER (PreAuthorize 오타로 CUSTOMER 취소 불가 버그)

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
