### PR TITLE
Perf/hot reservation pubsub batching

### DIFF
--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/dto/QueueMessage.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/dto/QueueMessage.java
@@ -1,0 +1,33 @@
+package com.tablekok.hotreservationservice.application.dto;
+
+import java.util.List;
+
+/**
+ * 스케줄러/예약 종료 시 Redis pub/sub 으로 주고받는 메시지.
+ *
+ * <ul>
+ *   <li>{@code TICK}  : 한 틱의 입장+대기 갱신을 한 번에 전달. 입장 유저는 {@code entryUserIds} 로 명시,
+ *       대기 유저는 리스트 없이 {@code updateCount} 만 보내 구독자가 자기 emitter 전체에 브로드캐스트한다.</li>
+ *   <li>{@code DONE}  : 특정 유저의 예약 종료 알림.</li>
+ * </ul>
+ */
+public record QueueMessage(
+	Type type,
+	List<String> entryUserIds,
+	String entryTtl,
+	String updateCount,
+	String doneUserId
+) {
+
+	public enum Type {
+		TICK, DONE
+	}
+
+	public static QueueMessage tick(List<String> entryUserIds, String entryTtl, String updateCount) {
+		return new QueueMessage(Type.TICK, entryUserIds, entryTtl, updateCount, null);
+	}
+
+	public static QueueMessage done(String userId) {
+		return new QueueMessage(Type.DONE, null, null, null, userId);
+	}
+}

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/service/QueueService.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/service/QueueService.java
@@ -2,15 +2,19 @@ package com.tablekok.hotreservationservice.application.service;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tablekok.exception.AppException;
+import com.tablekok.hotreservationservice.application.dto.QueueMessage;
 import com.tablekok.hotreservationservice.application.exception.HotReservationErrorCode;
 import com.tablekok.hotreservationservice.domain.repository.CacheStore;
 
@@ -25,6 +29,7 @@ public class QueueService {
 	// 사용자 ID를 키로, SseEmitter를 값으로 저장하여 관리
 	private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 	private final CacheStore cacheStore;
+	private final ObjectMapper objectMapper;
 
 	@Value("${queue.sse.ttl}")
 	private long SSE_TTL;
@@ -38,12 +43,18 @@ public class QueueService {
 	// 사용자를 대기열에 등록하고 생성한 이미터를 반환
 	public SseEmitter enterQueue(String userId) {
 		SseEmitter newEmitter = new SseEmitter(SSE_TTL);
-		this.emitters.put(userId, newEmitter);
+		// 같은 유저의 이전 연결이 있으면(중복/빠른 재연결) 옛 연결을 즉시 정리
+		SseEmitter oldEmitter = this.emitters.put(userId, newEmitter);
+		if (oldEmitter != null) {
+			oldEmitter.complete();
+		}
 
 		// 서버에서 emitter.complete()을 호출하거나, 클라이언트가 연결을 닫았을 때 실행될 콜백
 		newEmitter.onCompletion(() -> {
-				this.emitters.remove(userId);
-				cacheStore.removeUserFromQueue(userId);
+				// 현재 매핑이 '이 emitter'일 때만 정리 (재연결로 교체됐으면 건드리지 않음)
+				if (this.emitters.remove(userId, newEmitter)) {
+					cacheStore.removeUserFromQueue(userId);
+				}
 			}
 		);
 		newEmitter.onTimeout(newEmitter::complete);
@@ -55,7 +66,8 @@ public class QueueService {
 			return newEmitter;
 		}
 
-		cacheStore.addUserToQueue(userId, SSE_TTL);
+		// 큐에 없을 때만 추가 → 재연결해도 순번 유지
+		cacheStore.addUserToQueueIfAbsent(userId, SSE_TTL);
 		Long rank = cacheStore.getRank(userId);
 		sendEvent(newEmitter, userId, "queue", rank);
 
@@ -74,8 +86,7 @@ public class QueueService {
 	// 예약 완료 또는 시간 초과 시 사용자, 이미터를 삭제합니다.
 	public void completeReservation(String userId) {
 		cacheStore.removeAvailableUser(userId);
-		convertAndSend(userId, "done", "예약이 종료되었습니다.");
-
+		publish(QueueMessage.done(userId));
 	}
 
 	// 예약 허용 시간 초과 유저 삭제 및 입장 인원 반환
@@ -89,64 +100,67 @@ public class QueueService {
 
 	}
 
-	// 유저 예약 입장 및 순번 갱신 알림
+	// 유저 예약 입장 및 순번 갱신 알림 — 입장 그룹만 모아 한 번에 발행
 	public void processAllUsers(int count) {
-		Set<String> allUsers = cacheStore.getAllUsers();
-		int index = 0;
-		for (String userId : allUsers) {
-			if (index < count) {
-
-				// 예약 가능자 처리
-				addAvailableUser(userId);
-				index++;
-				continue;
-			}
-
-			// 나머지 사용자 순번 변경 알림. 몇명 입장 했는지 전달
-			convertAndSend(userId, "update", String.valueOf(count));
-			index++;
+		// 입장 대상 상위 count 명만 조회
+		List<String> entryUserIds = new ArrayList<>(cacheStore.getTopUsers(count));
+		if (entryUserIds.isEmpty()) {   // ← 빈자리는 있지만 큐가 비어서 입장자 0인 경우
+			return;
 		}
+		
+		// 예약 가능 공간으로 일괄 이동 + 대기열에서 일괄 삭제 (각각 단일 명령)
+		cacheStore.addAvailableUsers(entryUserIds, ENTRY_TTL);
+		cacheStore.removeUsersFromQueue(entryUserIds);
+
+		// 한 번의 발행: 입장 리스트 + 입장 TTL + 대기 갱신 인원(count)
+		publish(QueueMessage.tick(entryUserIds, String.valueOf(ENTRY_TTL), String.valueOf(count)));
 	}
 
-	// 예약 입장. AVAILABLE_USERS 리스트에 추가하고 알림
-	private void addAvailableUser(String userId) {
-		// 예약 가능 상태인 사용자 목록에 추가, 대기열에서 삭제
-		cacheStore.addAvailableUser(userId, ENTRY_TTL);
-		cacheStore.removeUserFromQueue(userId);
-
-		convertAndSend(userId, "entry", String.valueOf(ENTRY_TTL));
-	}
-
-	public void onMessage(String message) {
+	public void onMessage(String raw) {
 		try {
-			String[] parts = message.split(":");
-			if (parts.length < 3)
-				return;
-
-			String userId = parts[0];
-			String eventName = parts[1];
-			String data = parts[2];
-
-			SseEmitter emitter = emitters.get(userId);
-
-			if (emitter != null) {
-				log.info("내 서버에 연결된 유저 {}에게 {} 이벤트 전송", userId, eventName);
-				sendEvent(emitter, userId, eventName, data);
-
-				if ("done".equals(eventName)) {
-					emitter.complete();
-					emitters.remove(userId);
-				}
+			QueueMessage message = objectMapper.readValue(raw, QueueMessage.class);
+			switch (message.type()) {
+				case TICK -> handleTick(message);
+				case DONE -> handleDone(message);
 			}
-
 		} catch (Exception e) {
 			log.error("Redis 메시지 처리 중 오류 발생: {}", e.getMessage());
 		}
 	}
 
-	private void convertAndSend(String userId, String eventName, String data) {
-		String message = userId + ":" + eventName + ":" + data;
-		cacheStore.convertAndSend(message);
+	// 입장 유저에게 entry 전송 + 이 서버의 모든 emitter 에 순번 갱신 브로드캐스트
+	private void handleTick(QueueMessage message) {
+		if (message.entryUserIds() != null) {
+			for (String userId : message.entryUserIds()) {
+				SseEmitter emitter = emitters.get(userId);
+				if (emitter != null) {
+					log.info("내 서버에 연결된 입장 유저 {}에게 entry 전송", userId);
+					sendEvent(emitter, userId, "entry", message.entryTtl());
+				}
+			}
+		}
+
+		emitters.forEach((userId, emitter) -> sendEvent(emitter, userId, "update", message.updateCount()));
+	}
+
+	// 예약 종료 유저에게 done 전송 후 emitter 정리
+	private void handleDone(QueueMessage message) {
+		String userId = message.doneUserId();
+		SseEmitter emitter = emitters.get(userId);
+		if (emitter != null) {
+			log.info("내 서버에 연결된 유저 {}에게 done 이벤트 전송", userId);
+			sendEvent(emitter, userId, "done", "예약이 종료되었습니다.");
+			emitter.complete();
+			emitters.remove(userId, emitter);
+		}
+	}
+
+	private void publish(QueueMessage message) {
+		try {
+			cacheStore.convertAndSend(objectMapper.writeValueAsString(message));
+		} catch (JsonProcessingException e) {
+			log.error("pub/sub 메시지 직렬화 실패: {}", e.getMessage());
+		}
 	}
 
 	private <T> void sendEvent(SseEmitter emitter, String userId, String eventName, T data) {
@@ -158,7 +172,7 @@ public class QueueService {
 			);
 		} catch (IOException e) {
 			emitter.completeWithError(e);
-			emitters.remove(userId);
+			emitters.remove(userId, emitter);
 			log.warn(e.getMessage());
 		}
 

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/repository/CacheStore.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/repository/CacheStore.java
@@ -1,23 +1,27 @@
 package com.tablekok.hotreservationservice.domain.repository;
 
+import java.util.Collection;
 import java.util.Set;
 
 public interface CacheStore {
 
-	// 대기열에 추가
-	void addUserToQueue(String userId, long entryTtl);
+	// 대기열에 추가 (이미 있으면 순번 유지 — 재연결 대비)
+	void addUserToQueueIfAbsent(String userId, long sseTtl);
 
 	// 대기 순번 반환
 	Long getRank(String userId);
 
-	// 현재 대기 중인 모든 사용자 조회
-	Set<String> getAllUsers();
+	// 대기열 상위 count 명 조회 (입장 처리 대상)
+	Set<String> getTopUsers(long count);
 
-	// 유저를 예약 가능 공간에 추가
-	void addAvailableUser(String userId, long entryTtl);
+	// 유저들을 예약 가능 공간에 일괄 추가
+	void addAvailableUsers(Collection<String> userIds, long entryTtl);
 
 	// 대기열에서 사용자 삭제
 	void removeUserFromQueue(String userId);
+
+	// 대기열에서 사용자 일괄 삭제
+	void removeUsersFromQueue(Collection<String> userIds);
 
 	// 입장 유저 조회
 	Double findAvailableUser(String userId);

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/infrastructure/Cache/CacheStoreImpl.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/infrastructure/Cache/CacheStoreImpl.java
@@ -1,9 +1,12 @@
 package com.tablekok.hotreservationservice.infrastructure.Cache;
 
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 import com.tablekok.hotreservationservice.domain.repository.CacheStore;
@@ -24,9 +27,10 @@ public class CacheStoreImpl implements CacheStore {
 	private String PUB_SUB_CHANNEL;
 
 	@Override
-	public void addUserToQueue(String userId, long sseTtl) {
+	public void addUserToQueueIfAbsent(String userId, long sseTtl) {
 		long expireAt = System.currentTimeMillis() + sseTtl;
-		redisTemplate.opsForZSet().add(QUEUE_KEY, userId, (double)expireAt);
+		// ZADD NX: 큐에 없을 때만 추가 (이미 있으면 점수=순번 유지)
+		redisTemplate.opsForZSet().addIfAbsent(QUEUE_KEY, userId, (double)expireAt);
 	}
 
 	@Override
@@ -35,20 +39,36 @@ public class CacheStoreImpl implements CacheStore {
 	}
 
 	@Override
-	public Set<String> getAllUsers() {
-		// start: 0, end: -1 -> 전체 멤버 조회
-		return redisTemplate.opsForZSet().range(QUEUE_KEY, 0, -1);
+	public Set<String> getTopUsers(long count) {
+		// rank 0 ~ count-1 -> 점수 오름차순 상위 count 명
+		return redisTemplate.opsForZSet().range(QUEUE_KEY, 0, count - 1);
 	}
 
 	@Override
-	public void addAvailableUser(String userId, long entryTtl) {
+	public void addAvailableUsers(Collection<String> userIds, long entryTtl) {
+		if (userIds.isEmpty()) {
+			return;
+		}
 		long expireAt = System.currentTimeMillis() + entryTtl;
-		redisTemplate.opsForZSet().add(AVAILABLE_USERS_KEY, userId, (double)expireAt);
+		Set<ZSetOperations.TypedTuple<String>> tuples = userIds.stream()
+			.map(userId -> ZSetOperations.TypedTuple.of(userId, (double)expireAt))
+			.collect(Collectors.toSet());
+		// 멤버 여러 개를 단일 ZADD 로 추가
+		redisTemplate.opsForZSet().add(AVAILABLE_USERS_KEY, tuples);
 	}
 
 	@Override
 	public void removeUserFromQueue(String userId) {
 		redisTemplate.opsForZSet().remove(QUEUE_KEY, userId);
+	}
+
+	@Override
+	public void removeUsersFromQueue(Collection<String> userIds) {
+		if (userIds.isEmpty()) {
+			return;
+		}
+		// 멤버 여러 개를 단일 ZREM 으로 삭제
+		redisTemplate.opsForZSet().remove(QUEUE_KEY, userIds.toArray());
 	}
 
 	@Override

--- a/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/application/service/QueueServiceOnMessageTest.java
+++ b/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/application/service/QueueServiceOnMessageTest.java
@@ -1,0 +1,99 @@
+package com.tablekok.hotreservationservice.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tablekok.hotreservationservice.application.dto.QueueMessage;
+import com.tablekok.hotreservationservice.domain.repository.CacheStore;
+
+/**
+ * 구독 측(onMessage → handleTick/handleDone) 라우팅 로직 단위 테스트.
+ * Redis 불필요 — emitters 맵에 가짜 SseEmitter 를 심고 메시지를 흘려보내 검증한다.
+ */
+class QueueServiceOnMessageTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private QueueService service;
+	private Map<String, SseEmitter> emitters;
+
+	@BeforeEach
+	@SuppressWarnings("unchecked")
+	void setUp() {
+		service = new QueueService(mock(CacheStore.class), objectMapper);
+		// private final emitters 맵 참조를 꺼내 테스트가 직접 심는다
+		emitters = (Map<String, SseEmitter>) ReflectionTestUtils.getField(service, "emitters");
+	}
+
+	@Test
+	void tick_sends_entry_to_listed_and_broadcasts_update_to_all() throws Exception {
+		SseEmitter e1 = mock(SseEmitter.class); // 입장 대상
+		SseEmitter e2 = mock(SseEmitter.class); // 대기
+		emitters.put("u1", e1);
+		emitters.put("u2", e2);
+
+		service.onMessage(objectMapper.writeValueAsString(
+			QueueMessage.tick(List.of("u1"), "30000", "2")));
+
+		// u1: entry + update = 2번
+		ArgumentCaptor<SseEmitter.SseEventBuilder> c1 = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+		verify(e1, times(2)).send(c1.capture());
+		List<String> p1 = c1.getAllValues().stream()
+			.map(QueueServiceOnMessageTest::payload)
+			.collect(Collectors.toList());
+		assertThat(p1).anyMatch(s -> s.contains("event:entry") && s.contains("data:30000"));
+		assertThat(p1).anyMatch(s -> s.contains("event:update") && s.contains("data:2"));
+
+		// u2: update 1번만
+		ArgumentCaptor<SseEmitter.SseEventBuilder> c2 = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+		verify(e2, times(1)).send(c2.capture());
+		assertThat(payload(c2.getValue())).contains("event:update").contains("data:2");
+	}
+
+	@Test
+	void tick_skips_entry_user_not_connected_here() throws Exception {
+		SseEmitter e2 = mock(SseEmitter.class);
+		emitters.put("u2", e2); // u1 은 다른 서버에 연결됨(여기 없음)
+
+		service.onMessage(objectMapper.writeValueAsString(
+			QueueMessage.tick(List.of("u1"), "30000", "2")));
+
+		// NPE 없이, u2 는 update 만 받는다
+		verify(e2, times(1)).send(any(SseEmitter.SseEventBuilder.class));
+	}
+
+	@Test
+	void done_completes_and_removes_emitter() throws Exception {
+		SseEmitter e1 = mock(SseEmitter.class);
+		emitters.put("u1", e1);
+
+		service.onMessage(objectMapper.writeValueAsString(QueueMessage.done("u1")));
+
+		ArgumentCaptor<SseEmitter.SseEventBuilder> c = ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+		verify(e1).send(c.capture());
+		assertThat(payload(c.getValue())).contains("event:done");
+		verify(e1).complete();
+		assertThat(emitters).doesNotContainKey("u1");
+	}
+
+	// SseEventBuilder 는 내용을 바로 노출하지 않으므로 build() 로 펼쳐 문자열로 검증한다.
+	// 결과 예: "id:u1\nevent:entry\ndata:30000\n\n"
+	private static String payload(SseEmitter.SseEventBuilder builder) {
+		return builder.build().stream()
+			.map(data -> String.valueOf(data.getData()))
+			.collect(Collectors.joining());
+	}
+}

--- a/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/application/service/QueueServicePublishPerfTest.java
+++ b/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/application/service/QueueServicePublishPerfTest.java
@@ -1,0 +1,139 @@
+package com.tablekok.hotreservationservice.application.service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tablekok.hotreservationservice.domain.repository.CacheStore;
+import com.tablekok.hotreservationservice.infrastructure.Cache.CacheStoreImpl;
+
+/**
+ * 스케줄러 입장 처리(processAllUsers)의 PUBLISH 발행 비용을 전/후로 측정하는 수동 성능 테스트.
+ *
+ * <p>측정 지표
+ * <ul>
+ *   <li>A. 틱 소요시간: processAllUsers(count) wall-clock (ms)</li>
+ *   <li>B. PUBLISH 호출 수: CacheStore.convertAndSend 호출 횟수 (Mockito spy 로 카운트)</li>
+ * </ul>
+ *
+ * <p>전제: 로컬 Redis 가 떠 있어야 한다(기본 localhost:6379 / pw systempass — dev 설정 기준).
+ * 환경변수 REDIS_HOST / REDIS_PORT / REDIS_PASSWORD 로 덮어쓸 수 있다.
+ *
+ * <p>CI 에서 자동 실행되지 않도록 환경변수 RUN_REDIS_PERF=true 일 때만 활성화된다.
+ * 실행 예 (PowerShell):
+ * <pre>
+ *   $env:RUN_REDIS_PERF="true"; ./gradlew :hot-reservation-service:test --tests "*QueueServicePublishPerfTest" --info
+ * </pre>
+ * 결과는 콘솔과 build/queue-perf-result.txt 양쪽에 남는다.
+ */
+@EnabledIfEnvironmentVariable(named = "RUN_REDIS_PERF", matches = "true")
+class QueueServicePublishPerfTest {
+
+	private static final String QUEUE_KEY = "reservation:queue";
+	private static final String AVAILABLE_USERS_KEY = "reservation:available_users";
+	private static final String PUB_SUB_CHANNEL = "waiting-queue";
+
+	private static final long ENTRY_TTL = 30_000L;
+	private static final int ENTRY_COUNT = 50; // 한 틱에 입장시키는 인원 (availableUserLimit 기준)
+
+	private LettuceConnectionFactory connectionFactory;
+	private RedisTemplate<String, String> redisTemplate;
+
+	@BeforeEach
+	void setUp() {
+		String host = envOrDefault("REDIS_HOST", "localhost");
+		int port = Integer.parseInt(envOrDefault("REDIS_PORT", "6379"));
+		String password = envOrDefault("REDIS_PASSWORD", "systempass");
+
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+		if (password != null && !password.isBlank()) {
+			config.setPassword(password);
+		}
+		connectionFactory = new LettuceConnectionFactory(config);
+		connectionFactory.afterPropertiesSet();
+
+		redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.afterPropertiesSet();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (redisTemplate != null) {
+			redisTemplate.delete(List.of(QUEUE_KEY, AVAILABLE_USERS_KEY));
+		}
+		if (connectionFactory != null) {
+			connectionFactory.destroy();
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {1_000, 5_000, 10_000})
+	void measurePublishCost(int queueSize) {
+		// 1) 큐 초기화 후 N명 시드
+		redisTemplate.delete(List.of(QUEUE_KEY, AVAILABLE_USERS_KEY));
+		for (int i = 0; i < queueSize; i++) {
+			redisTemplate.opsForZSet().add(QUEUE_KEY, "user-" + i, i);
+		}
+
+		// 2) 실제 Redis 를 쓰는 CacheStore + PUBLISH 카운트용 spy
+		CacheStoreImpl realStore = new CacheStoreImpl(redisTemplate);
+		ReflectionTestUtils.setField(realStore, "QUEUE_KEY", QUEUE_KEY);
+		ReflectionTestUtils.setField(realStore, "AVAILABLE_USERS_KEY", AVAILABLE_USERS_KEY);
+		ReflectionTestUtils.setField(realStore, "PUB_SUB_CHANNEL", PUB_SUB_CHANNEL);
+		CacheStore store = Mockito.spy(realStore);
+
+		QueueService service = new QueueService(store, new ObjectMapper());
+		ReflectionTestUtils.setField(service, "ENTRY_TTL", ENTRY_TTL);
+
+		// 3) 측정: 틱 소요시간(A)
+		long start = System.nanoTime();
+		service.processAllUsers(ENTRY_COUNT);
+		long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+		// 4) 측정: PUBLISH 호출 수(B)
+		long publishCalls = Mockito.mockingDetails(store).getInvocations().stream()
+			.filter(inv -> "convertAndSend".equals(inv.getMethod().getName()))
+			.count();
+
+		record(queueSize, elapsedMs, publishCalls);
+	}
+
+	private void record(int queueSize, long elapsedMs, long publishCalls) {
+		String line = String.format(
+			"[QUEUE-PERF] queueSize=%d  entryCount=%d  elapsedMs=%d  publishCalls=%d",
+			queueSize, ENTRY_COUNT, elapsedMs, publishCalls);
+		System.out.println(line);
+		try {
+			Path out = Path.of("build", "queue-perf-result.txt");
+			Files.createDirectories(out.getParent());
+			Files.writeString(out, line + System.lineSeparator(),
+				StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+		} catch (IOException e) {
+			System.out.println("[QUEUE-PERF] 결과 파일 기록 실패: " + e.getMessage());
+		}
+	}
+
+	private static String envOrDefault(String key, String def) {
+		String v = System.getenv(key);
+		return (v == null || v.isBlank()) ? def : v;
+	}
+}


### PR DESCRIPTION
## 🔗 Issue 번호
- X

## 🛠 작업 내역
- 인기예약 대기열 pub/sub 발행 비용 최적화 (틱당 PUBLISH N회 → 1회)
- 입장 처리 Redis 명령 다건 일괄화 (큐 클수록 선형 증가하던 틱 시간 평탄화)
- SSE 재연결 시 emitter/큐 순번 정합성 문제 정리
- 발행/구독 테스트 추가

## 🔄 변경 사항
- 틱당 유저별 PUBLISH → 입장 리스트 1건(JSON 메시지)로 배칭
- ZADD/ZREM 다건 처리 + 입장 대상만 상위 N개 ZRANGE 조회
- 입장자 없는 틱은 발행 스킵
- onMessage를 JSON 기반 TICK/DONE 라우팅으로 변경 (+ QueueMessage DTO)
- emitter 조건부 제거(remove(key,value)) + 재연결 순번 유지(ZADD NX) + 옛 연결 즉시 정리
- 테스트: QueueServiceOnMessageTest(라우팅 검증), QueueServicePublishPerfTest(발행 측정, RUN_REDIS_PERF 게이트)

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
