### PR TITLE
Fix/hot reservation duplicate prevention

### DIFF
--- a/hot-reservation-service/build.gradle
+++ b/hot-reservation-service/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'                                       // 리포지토리 슬라이스 테스트용 임베디드 DB
+    testImplementation 'org.testcontainers:junit-jupiter'                     // 동시성 락 테스트용 Redis 컨테이너
 }
 dependencyManagement {
     imports {

--- a/hot-reservation-service/db/add_active_reservation_unique_index.sql
+++ b/hot-reservation-service/db/add_active_reservation_unique_index.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- 인기예약 중복 방지 — DB 최종 안전망 (분산락 + DB 제약 이중 방어)
+-- =============================================================================
+-- 분산락(Redisson)은 락 만료 / TOCTOU 상황에서 중복을 100% 막지 못한다.
+-- 따라서 DB 부분 유니크 인덱스로 "활성 예약"의 슬롯 유일성을 원자적으로 보장한다.
+--   - 락       : 요청 단계 경합 감소 (성능)
+--   - DB 인덱스 : 어떤 경우에도 뚫리지 않는 최종 펜스 (정합성)
+--
+-- 활성 예약 = 취소(CANCELED) / 거절(REJECT) / 소프트삭제(deleted_at) 가 아닌 예약
+--   → 취소·거절된 슬롯은 재예약이 가능해야 하므로 유일성 판정에서 제외한다.
+--
+-- 적용 (현재 수동 1회 실행, Flyway 전환은 개선 과제):
+--   psql -U postgres -d tk-reservation -f add_active_reservation_unique_index.sql
+-- =============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_active_reservation_slot
+    ON p_reservation (store_id, reservation_date, reservation_time)
+    WHERE deleted_at IS NULL
+      AND reservation_status NOT IN ('CANCELED', 'REJECT');

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/service/HotReservationService.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/service/HotReservationService.java
@@ -4,17 +4,13 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.tablekok.hotreservationservice.application.client.StoreClient;
 import com.tablekok.hotreservationservice.application.client.dto.GetStoreReservationPolicyResponse;
 import com.tablekok.hotreservationservice.application.dto.command.CreateReservationCommand;
 import com.tablekok.hotreservationservice.application.dto.result.CreateReservationResult;
-import com.tablekok.hotreservationservice.domain.entity.Reservation;
-import com.tablekok.hotreservationservice.domain.repository.ReservationRepository;
 import com.tablekok.hotreservationservice.domain.service.ReservationDomainService;
 import com.tablekok.hotreservationservice.domain.vo.StoreReservationPolicy;
-import com.tablekok.hotreservationservice.global.annotation.DistributedLock;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,40 +19,24 @@ import lombok.RequiredArgsConstructor;
 public class HotReservationService {
 	private final ReservationDomainService reservationDomainService;
 	private final StoreClient storeClient;
-	private final ReservationRepository reservationRepository;
+	private final ReservationCommitter reservationCommitter;
 
 	// 예약 생성(접수)
-	@Transactional
-	@DistributedLock(key = "'reservation:' + #command.storeId() + ':' + #command.reservationDateTime().getReservationDate()")
 	public CreateReservationResult createReservation(CreateReservationCommand command) {
-		validateReservationConstraints(command);
+		// 락 밖: 외부 호출이 필요한 사전 검증 (락 보유시간 최소화)
+		validateBeforeLock(command);
 
-		Reservation newReservation = Reservation.create(
-			command.userId(),
-			command.storeId(),
-			command.reservationDateTime(),
-			command.headcount(),
-			command.deposit()
-		);
-
-		reservationRepository.save(newReservation);
-		return CreateReservationResult.of(newReservation);
+		// 락 안: 중복 검증 + 저장 (분산락 + 트랜잭션)
+		return reservationCommitter.commit(command);
 	}
 
-	// 생성 전 검증
-	private void validateReservationConstraints(CreateReservationCommand command) {
-		// 도메인 서비스에서 검증하는게 맞나
+	// 락 밖 사전 검증 (인기 음식점 여부 / 예약 정책) — 외부(store-service) 호출
+	private void validateBeforeLock(CreateReservationCommand command) {
 		// 인기 음식점의 요청인지 확인
 		List<UUID> hotStores = storeClient.getHotStores();
 		reservationDomainService.validateHotStore(
 			hotStores,
 			command.storeId()
-		);
-
-		// 그 시간대 예약이 있는지
-		reservationDomainService.validateDuplicateReservation(
-			command.storeId(),
-			command.reservationDateTime()
 		);
 
 		// 예약할 음식점의 예약 정책에 준수하는지

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/service/ReservationCommitter.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/application/service/ReservationCommitter.java
@@ -1,0 +1,43 @@
+package com.tablekok.hotreservationservice.application.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tablekok.hotreservationservice.application.dto.command.CreateReservationCommand;
+import com.tablekok.hotreservationservice.application.dto.result.CreateReservationResult;
+import com.tablekok.hotreservationservice.domain.entity.Reservation;
+import com.tablekok.hotreservationservice.domain.repository.ReservationRepository;
+import com.tablekok.hotreservationservice.domain.service.ReservationDomainService;
+import com.tablekok.hotreservationservice.global.annotation.DistributedLock;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationCommitter {
+
+	private final ReservationDomainService reservationDomainService;
+	private final ReservationRepository reservationRepository;
+
+	// 분산락 임계구역 — 중복 검증 + 저장만 수행 (외부 호출은 락 밖에서 끝낸 상태)
+	@Transactional
+	@DistributedLock(key = "'reservation:' + #command.storeId() + ':' + #command.reservationDateTime().getReservationDate() + ':' + #command.reservationDateTime().getReservationTime()")
+	public CreateReservationResult commit(CreateReservationCommand command) {
+		// 활성 예약 중 동일 슬롯이 있는지
+		reservationDomainService.validateDuplicateReservation(
+			command.storeId(),
+			command.reservationDateTime()
+		);
+
+		Reservation newReservation = Reservation.create(
+			command.userId(),
+			command.storeId(),
+			command.reservationDateTime(),
+			command.headcount(),
+			command.deposit()
+		);
+
+		reservationRepository.save(newReservation);
+		return CreateReservationResult.of(newReservation);
+	}
+}

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/entity/ReservationStatus.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/entity/ReservationStatus.java
@@ -1,5 +1,7 @@
 package com.tablekok.hotreservationservice.domain.entity;
 
+import java.util.Set;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,4 +16,7 @@ public enum ReservationStatus {
 	NOSHOW("고객이 방문하지 않음");
 
 	private final String description;
+
+	// 슬롯을 비우는(점유하지 않는) 상태 — 중복 예약 판정 시 제외
+	public static final Set<ReservationStatus> SLOT_FREEING = Set.of(CANCELED, REJECT);
 }

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/repository/ReservationRepository.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/repository/ReservationRepository.java
@@ -10,8 +10,8 @@ public interface ReservationRepository {
 	// 예약 저장
 	void save(Reservation newReservation);
 
-	// 이미 그 시간대 예약이 있는지 확인용
-	boolean existsByStoreIdAndReservationDateTimeReservationDateAndReservationDateTimeReservationTime(
+	// 활성 예약(취소/거절/삭제 제외) 중 동일 슬롯이 있는지 확인용
+	boolean existsActiveReservation(
 		UUID storeId, LocalDate reservationDate, LocalTime reservationTime);
 
 }

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/service/ReservationDomainService.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/domain/service/ReservationDomainService.java
@@ -79,10 +79,10 @@ public class ReservationDomainService {
 		}
 	}
 
-	// 중복 예약인지
+	// 중복 예약인지 (취소/거절/삭제된 예약은 슬롯을 점유하지 않으므로 제외)
 	@Transactional(readOnly = true)
 	public void validateDuplicateReservation(UUID storeId, ReservationDateTime reservationDateTime) {
-		boolean exists = reservationRepository.existsByStoreIdAndReservationDateTimeReservationDateAndReservationDateTimeReservationTime(
+		boolean exists = reservationRepository.existsActiveReservation(
 			storeId,
 			reservationDateTime.getReservationDate(),
 			reservationDateTime.getReservationTime()

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/infrastructure/repository/ReservationJpaRepository.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/infrastructure/repository/ReservationJpaRepository.java
@@ -2,18 +2,31 @@ package com.tablekok.hotreservationservice.infrastructure.repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Collection;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.tablekok.hotreservationservice.domain.entity.Reservation;
+import com.tablekok.hotreservationservice.domain.entity.ReservationStatus;
 
 public interface ReservationJpaRepository extends JpaRepository<Reservation, UUID> {
 
-	boolean existsByStoreIdAndReservationDateTimeReservationDateAndReservationDateTimeReservationTime(
-		UUID storeId,
-		LocalDate reservationDate,
-		LocalTime reservationTime
+	@Query("""
+		select count(r) > 0 from Reservation r
+		 where r.storeId = :storeId
+		   and r.reservationDateTime.reservationDate = :reservationDate
+		   and r.reservationDateTime.reservationTime = :reservationTime
+		   and r.reservationStatus not in :excludedStatuses
+		   and r.deletedAt is null
+		""")
+	boolean existsActiveReservation(
+		@Param("storeId") UUID storeId,
+		@Param("reservationDate") LocalDate reservationDate,
+		@Param("reservationTime") LocalTime reservationTime,
+		@Param("excludedStatuses") Collection<ReservationStatus> excludedStatuses
 	);
 
 }

--- a/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/infrastructure/repository/ReservationJpaRepositoryAdapter.java
+++ b/hot-reservation-service/src/main/java/com/tablekok/hotreservationservice/infrastructure/repository/ReservationJpaRepositoryAdapter.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 import com.tablekok.hotreservationservice.domain.entity.Reservation;
+import com.tablekok.hotreservationservice.domain.entity.ReservationStatus;
 import com.tablekok.hotreservationservice.domain.repository.ReservationRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -22,10 +23,10 @@ public class ReservationJpaRepositoryAdapter implements ReservationRepository {
 	}
 
 	@Override
-	public boolean existsByStoreIdAndReservationDateTimeReservationDateAndReservationDateTimeReservationTime(
+	public boolean existsActiveReservation(
 		UUID storeId, LocalDate reservationDate, LocalTime reservationTime) {
-		return reservationJpaRepository.existsByStoreIdAndReservationDateTimeReservationDateAndReservationDateTimeReservationTime(
-			storeId, reservationDate, reservationTime);
+		return reservationJpaRepository.existsActiveReservation(
+			storeId, reservationDate, reservationTime, ReservationStatus.SLOT_FREEING);
 	}
 
 }

--- a/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/application/service/ReservationCommitterConcurrencyTest.java
+++ b/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/application/service/ReservationCommitterConcurrencyTest.java
@@ -1,0 +1,154 @@
+package com.tablekok.hotreservationservice.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.tablekok.hotreservationservice.application.client.StoreClient;
+import com.tablekok.hotreservationservice.application.dto.command.CreateReservationCommand;
+import com.tablekok.hotreservationservice.domain.vo.ReservationDateTime;
+import com.tablekok.hotreservationservice.infrastructure.repository.ReservationJpaRepository;
+
+/**
+ * 분산락 동시성 테스트 — 같은 슬롯에 N명이 동시에 예약해도 "딱 1건만" 성공하는지 검증.
+ *
+ * - 실제 Redis(Testcontainers)로 Redisson 분산락을 띄운다.
+ * - DB 유니크 제약은 적용하지 않는다(엔티티 스키마만) → 1건만 생기면 "막은 건 락"으로 확정된다.
+ * - 락이 걸린 ReservationCommitter.commit()을 직접 동시 호출한다(외부 호출/정책 검증은 락 밖이라 제외).
+ *
+ * ⚠️ 실행에 Docker 필요. (Docker 데몬이 떠 있어야 Redis 컨테이너가 기동됨)
+ */
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 지정한 H2를 그대로 사용(임베디드 교체 끔)
+@ActiveProfiles("test")
+@Testcontainers
+@TestPropertySource(properties = {
+	// 앱이 요구하는 @Value 프로퍼티 (컨텍스트 기동용)
+	"queue.sse.ttl=120000",
+	"reservation.entry.ttl=30000",
+	"reservation.available.user.limit=50",
+	"reservation.process.interval=3600000",          // 테스트 중 스케줄러가 돌지 않게 크게
+	"redis.queue.key=reservation:queue",
+	"redis.available.users.key=reservation:available_users",
+	"redis.pubsub.channel=waiting-queue",
+	// 디스커버리/트레이싱 비활성화
+	"eureka.client.enabled=false",
+	"spring.cloud.discovery.enabled=false",
+	"management.tracing.enabled=false",
+	// H2 데이터소스 (부분 유니크 인덱스 없음 → 락만 검증)
+	"spring.datasource.url=jdbc:h2:mem:locktest;DB_CLOSE_DELAY=-1",
+	"spring.datasource.driver-class-name=org.h2.Driver",
+	"spring.datasource.username=sa",
+	"spring.datasource.password=",
+	"spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class ReservationCommitterConcurrencyTest {
+
+	private static final String REDIS_PASSWORD = "testpass";
+
+	@Container
+	static final GenericContainer<?> REDIS =
+		new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+			.withExposedPorts(6379)
+			.withCommand("redis-server", "--requirepass", REDIS_PASSWORD); // 앱이 AUTH를 보내므로 컨테이너도 비번 요구
+
+	@DynamicPropertySource
+	static void redisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.redis.host", REDIS::getHost);
+		registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+		registry.add("spring.data.redis.password", () -> REDIS_PASSWORD);
+	}
+
+	private static final UUID STORE = UUID.randomUUID();
+	private static final LocalDate DATE = LocalDate.now().plusDays(1);
+	private static final LocalTime TIME = LocalTime.of(18, 0);
+
+	// commit()은 StoreClient를 호출하지 않음. 컨텍스트 기동 시 실제 Feign 빈 생성을 피하려 mock으로 대체.
+	@MockitoBean
+	private StoreClient storeClient;
+
+	@Autowired
+	private ReservationCommitter reservationCommitter;
+	@Autowired
+	private ReservationJpaRepository reservationJpaRepository;
+
+	@Test
+	void 같은_슬롯에_200명이_동시에_예약해도_1건만_성공한다() throws InterruptedException {
+		int concurrentUsers = 200;
+		ExecutorService pool = Executors.newFixedThreadPool(concurrentUsers);
+		CountDownLatch ready = new CountDownLatch(concurrentUsers); // 전원 준비 대기
+		CountDownLatch start = new CountDownLatch(1);               // 동시 출발 신호
+		AtomicInteger success = new AtomicInteger();
+		AtomicInteger failure = new AtomicInteger();
+		Queue<Throwable> errors = new ConcurrentLinkedQueue<>();
+
+		for (int i = 0; i < concurrentUsers; i++) {
+			pool.execute(() -> {
+				ready.countDown();
+				try {
+					start.await();                          // 모두 여기서 멈췄다가
+					reservationCommitter.commit(command()); // 동시에 같은 슬롯 예약 시도
+					success.incrementAndGet();
+				} catch (Exception e) {
+					failure.incrementAndGet();              // 중복/락대기초과 등은 실패로 집계
+					errors.add(e);                          // 실패 원인 수집(진단용)
+				}
+			});
+		}
+
+		ready.await();        // 200개 스레드가 모두 출발선에 섰는지 확인
+		start.countDown();    // 동시 출발
+		pool.shutdown();
+		boolean finished = pool.awaitTermination(60, TimeUnit.SECONDS);
+
+		// 실패 예외 종류 — 정상이면 "중복 예약" 예외만 있어야 함. 진단 위해 메시지에 노출.
+		List<String> distinctErrors = errors.stream()
+			.map(e -> e.getClass().getSimpleName() + ": " + e.getMessage())
+			.distinct()
+			.toList();
+
+		assertThat(finished).isTrue();
+		assertThat(success.get())
+			.as("성공은 1건이어야 함. 실제 실패 예외 종류=%s", distinctErrors)
+			.isEqualTo(1);
+		assertThat(reservationJpaRepository.count())
+			.as("DB에는 1건만 저장돼야 함")
+			.isEqualTo(1);
+		assertThat(failure.get()).isEqualTo(concurrentUsers - 1);    // 나머지는 실패
+	}
+
+	private CreateReservationCommand command() {
+		return CreateReservationCommand.builder()
+			.userId(UUID.randomUUID())                                       // 신청자는 제각각
+			.storeId(STORE)                                                  // 같은 가게
+			.reservationDateTime(ReservationDateTime.of(LocalDateTime.of(DATE, TIME))) // 같은 슬롯
+			.headcount(2)
+			.deposit(0)                                                      // deposit 0 → RESERVED 상태
+			.build();
+	}
+}

--- a/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/infrastructure/repository/ReservationJpaRepositoryTest.java
+++ b/hot-reservation-service/src/test/java/com/tablekok/hotreservationservice/infrastructure/repository/ReservationJpaRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.tablekok.hotreservationservice.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.tablekok.hotreservationservice.domain.entity.Reservation;
+import com.tablekok.hotreservationservice.domain.entity.ReservationStatus;
+import com.tablekok.hotreservationservice.domain.vo.ReservationDateTime;
+
+/**
+ * existsActiveReservation 쿼리 검증 — "활성 예약"만 중복으로 판정하는지 확인.
+ * (취소/거절된 예약은 슬롯을 비우므로 중복에서 제외되어야 한다)
+ * 임베디드 H2 슬라이스 테스트.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+class ReservationJpaRepositoryTest {
+
+	private static final UUID STORE = UUID.randomUUID();
+	private static final UUID USER = UUID.randomUUID();
+	private static final LocalDate DATE = LocalDate.of(2026, 7, 1);
+	private static final LocalTime TIME = LocalTime.of(18, 0);
+
+	@Autowired
+	private ReservationJpaRepository repository;
+	@Autowired
+	private TestEntityManager em;
+
+	@Test
+	void 활성_예약이_있으면_중복으로_차단된다() {
+		save(reservation(DATE, TIME)); // RESERVED
+
+		boolean exists = repository.existsActiveReservation(
+			STORE, DATE, TIME, ReservationStatus.SLOT_FREEING);
+
+		assertThat(exists).isTrue();
+	}
+
+	@Test
+	void 취소되거나_거절된_예약만_있으면_재예약이_허용된다() {
+		Reservation canceled = reservation(DATE, TIME);
+		canceled.cancel();
+		Reservation rejected = reservation(DATE, TIME);
+		rejected.reject();
+		save(canceled);
+		save(rejected);
+
+		boolean exists = repository.existsActiveReservation(
+			STORE, DATE, TIME, ReservationStatus.SLOT_FREEING);
+
+		assertThat(exists).isFalse();
+	}
+
+	@Test
+	void 다른_시간대_예약은_중복으로_보지_않는다() {
+		save(reservation(DATE, LocalTime.of(20, 0))); // 20:00 활성 예약
+
+		boolean exists = repository.existsActiveReservation(
+			STORE, DATE, TIME, ReservationStatus.SLOT_FREEING); // 18:00 조회
+
+		assertThat(exists).isFalse();
+	}
+
+	private Reservation reservation(LocalDate date, LocalTime time) {
+		return Reservation.create(
+			USER, STORE, ReservationDateTime.of(LocalDateTime.of(date, time)), 2, 0);
+	}
+
+	private void save(Reservation reservation) {
+		em.persist(reservation);
+		em.flush();
+	}
+}


### PR DESCRIPTION
## 🔗 Issue 번호
- X

## 🛠 작업 내역
- 다중 인스턴스 환경에서 같은 슬롯 동시 예약 시 발생하던 중복 예약 방지 보강 (분산락 + DB 제약 이중 방어)

## 🔄 변경 사항
- 중복 검증을 "활성 예약"(취소/거절/삭제 제외) 기준으로 변경 → 취소 후 재예약 가능
- 분산락 임계구역 축소: store-service 호출을 락 밖으로 분리, 락+트랜잭션 핵심을 `ReservationCommitter`로 분리 (self-invocation 회피)
- 분산락 키를 (가게+날짜) → (가게+날짜+시간)으로 세분화 → 시간대별 병렬 처리

## ✨ 새로운 기능
- 중복 예약 방지용 DB 부분 유니크 인덱스 스크립트 추가 (최종 안전망, 현재 수동 적용)
- 테스트 추가: 활성 예약 중복 검증(H2 슬라이스), 200명 동시 요청 시 1건만 성공(Testcontainers)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
