### PR TITLE
fix: 예약 가능 시간 조회를 활성 예약 기준으로 변경

### DIFF
--- a/reservation-service/src/main/java/com/tablekok/reservation_service/application/service/ReservationService.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/application/service/ReservationService.java
@@ -71,8 +71,7 @@ public class ReservationService {
 	// 특정 식당의 선택 일자의 예약 목록 조회(프론트에서 예약 가능 시간 선택 표시를 위해)
 	@Transactional(readOnly = true)
 	public GetReservedTimeResult getReservedTime(UUID storeId, LocalDate date) {
-		List<Reservation> findReservations = reservationRepository.findByStoreIdAndReservationDateTime_ReservationDate(
-			storeId, date);
+		List<Reservation> findReservations = reservationRepository.findActiveByStoreIdAndDate(storeId, date);
 		return GetReservedTimeResult.of(findReservations);
 	}
 

--- a/reservation-service/src/main/java/com/tablekok/reservation_service/domain/repository/ReservationRepository.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/domain/repository/ReservationRepository.java
@@ -30,6 +30,6 @@ public interface ReservationRepository {
 	// 해당 음식점의 모든 예약 조회
 	Page<Reservation> findByStoreId(UUID storeId, Pageable normalizedPageable);
 
-	// 해당 식당의 특정 일 예약 목록 조회
-	List<Reservation> findByStoreIdAndReservationDateTime_ReservationDate(UUID storeId, LocalDate date);
+	// 해당 식당의 특정 일 활성 예약 목록 조회 (취소/거절/삭제 제외 — 예약 가능 시간 표시용)
+	List<Reservation> findActiveByStoreIdAndDate(UUID storeId, LocalDate date);
 }

--- a/reservation-service/src/main/java/com/tablekok/reservation_service/infrastructure/repository/ReservationJpaRepository.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/infrastructure/repository/ReservationJpaRepository.java
@@ -39,5 +39,16 @@ public interface ReservationJpaRepository extends JpaRepository<Reservation, UUI
 
 	Page<Reservation> findByStoreId(UUID storeId, Pageable pageable);
 
-	List<Reservation> findByStoreIdAndReservationDateTime_ReservationDate(UUID storeId, LocalDate date);
+	@Query("""
+		select r from Reservation r
+		 where r.storeId = :storeId
+		   and r.reservationDateTime.reservationDate = :reservationDate
+		   and r.reservationStatus not in :excludedStatuses
+		   and r.deletedAt is null
+		""")
+	List<Reservation> findActiveByStoreIdAndDate(
+		@Param("storeId") UUID storeId,
+		@Param("reservationDate") LocalDate reservationDate,
+		@Param("excludedStatuses") Collection<ReservationStatus> excludedStatuses
+	);
 }

--- a/reservation-service/src/main/java/com/tablekok/reservation_service/infrastructure/repository/ReservationRepositoryAdapter.java
+++ b/reservation-service/src/main/java/com/tablekok/reservation_service/infrastructure/repository/ReservationRepositoryAdapter.java
@@ -57,8 +57,9 @@ public class ReservationRepositoryAdapter implements ReservationRepository {
 	}
 
 	@Override
-	public List<Reservation> findByStoreIdAndReservationDateTime_ReservationDate(UUID storeId, LocalDate date) {
-		return reservationJpaRepository.findByStoreIdAndReservationDateTime_ReservationDate(storeId, date);
+	public List<Reservation> findActiveByStoreIdAndDate(UUID storeId, LocalDate date) {
+		return reservationJpaRepository.findActiveByStoreIdAndDate(
+			storeId, date, ReservationStatus.SLOT_FREEING);
 	}
 
 }

--- a/reservation-service/src/test/java/com/tablekok/reservation_service/infrastructure/repository/ReservationJpaRepositoryTest.java
+++ b/reservation-service/src/test/java/com/tablekok/reservation_service/infrastructure/repository/ReservationJpaRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,8 @@ import com.tablekok.reservation_service.domain.entity.ReservationStatus;
 import com.tablekok.reservation_service.domain.vo.ReservationDateTime;
 
 /**
- * existsActiveReservation 쿼리 검증 — "활성 예약"만 중복으로 판정하는지 확인.
- * (취소/거절된 예약은 슬롯을 비우므로 중복에서 제외되어야 한다)
+ * 활성 예약 기준 쿼리 검증 — 중복 판정(existsActiveReservation)과
+ * 예약 가능 시간 조회(findActiveByStoreIdAndDate) 모두 취소/거절/삭제 예약을 제외하는지 확인.
  * 임베디드 H2 슬라이스 테스트.
  */
 @DataJpaTest
@@ -69,6 +70,21 @@ class ReservationJpaRepositoryTest {
 			STORE, DATE, TIME, ReservationStatus.SLOT_FREEING); // 18:00 조회
 
 		assertThat(exists).isFalse();
+	}
+
+	@Test
+	void 예약가능시간_조회는_취소_거절된_예약을_제외한다() {
+		save(reservation(DATE, LocalTime.of(18, 0)));            // 활성
+		Reservation canceled = reservation(DATE, LocalTime.of(19, 0));
+		canceled.cancel();                                       // 취소 → 제외 대상
+		save(canceled);
+
+		List<Reservation> result = repository.findActiveByStoreIdAndDate(
+			STORE, DATE, ReservationStatus.SLOT_FREEING);
+
+		assertThat(result)
+			.extracting(r -> r.getReservationDateTime().getReservationTime())
+			.containsExactly(LocalTime.of(18, 0));               // 취소된 19:00은 빠짐
 	}
 
 	private Reservation reservation(LocalDate date, LocalTime time) {


### PR DESCRIPTION
## 🔗 Issue 번호
- close # X

## 🛠 작업 내역
- 예약 가능 시간 조회(getReservedTime)를 활성 예약 기준으로 변경

## 🔄 변경 사항
- #190에서 중복 판정을 활성 예약 기준(취소/거절/삭제 제외)으로 바꾸면서
  조회와 기준이 어긋난 상태였음
  - 생성: 취소된 슬롯 재예약 **허용**
  - 조회: 취소된 슬롯도 **반환** → 프론트 화면엔 "예약됨"으로 표시
  - 결과: 사용자가 실제로 예약 가능한 시간을 막힌 것으로 오인
- 조회 쿼리를 중복 판정과 동일한 활성 기준으로 통일
  - findByStoreIdAndReservationDateTime_ReservationDate
    → findActiveByStoreIdAndDate (@Query, status not in / deletedAt is null)
  - 제외 상태(SLOT_FREEING)는 어댑터에서 바인딩, 포트/서비스는 상태를 모르게 유지

## ✨ 새로운 기능
- 없음 (기존 동작 수정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가? (develop)
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 🧪 테스트
| 테스트 | 케이스 | 결과 |
| --- | --- | --- |
| ReservationJpaRepositoryTest | 예약 가능 시간 조회가 취소/거절된 예약을 제외하는지 | ✅ |

기존 3케이스(중복 판정)에 조회 케이스 1개를 추가해 총 4케이스 통과.